### PR TITLE
External links PWA page

### DIFF
--- a/externalLinks.html
+++ b/externalLinks.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>External_links</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <link rel="manifest" href="manifest.json">
+      <link href="https://fonts.googleapis.com/css?family=Hanalei+Fill" rel="stylesheet">
+  </head>
+
+  <p class="header">Misc Link Types</p>
+  <section>
+    <a href="http://google.com">External link</a>
+  </section>
+
+  <section>
+    <a href="mailto://example@example.com">Email link</a>
+  </section>
+
+  <section>
+    <a href="tel://1234567890">Telephone link</a>
+  </section>
+
+</html>


### PR DESCRIPTION
New external links test page.

Used the page created on my repo https://andiaj.github.io/testapp/externalLinks and works properly in the newly created smoke tests: `externalLinkPWATest` `emailLinkPWATest` `telephoneLinkPWATest`

• The PWA is properly installed
• The external links are properly identified and clicked
• The external links are properly opened